### PR TITLE
Crawler para MPSP

### DIFF
--- a/crawler/prototipos/MPSP/crawler-mpsp.go
+++ b/crawler/prototipos/MPSP/crawler-mpsp.go
@@ -89,13 +89,13 @@ func contentLink(sel *goquery.Selection, month int) (string, error) {
 
 func fetchContent(category string, month int, year int) ([]byte, error) {
 	link := fmt.Sprintf("%s%s", linkPrincipal, category)
-	res, err := http.Get(link)
+	resCategory, err := http.Get(link)
 	if err != nil {
 		return nil, fmt.Errorf("Error while trying to make the Get request to (%s)", link)
 	}
-	defer res.Body.Close()
+	defer resCategory.Body.Close()
 
-	doc, err := goquery.NewDocumentFromReader(res.Body)
+	doc, err := goquery.NewDocumentFromReader(resCategory.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Error while casting reader to goquery.document (%s)", link)
 	}
@@ -125,13 +125,13 @@ func fetchContent(category string, month int, year int) ([]byte, error) {
 	}
 
 	//Fetch content
-	res, err = http.Get(ssLink)
+	resFile, err := http.Get(ssLink)
 	if err != nil {
 		return nil, fmt.Errorf("Error while trying to make the Get request to (%s)", ssLink)
 	}
-	defer res.Body.Close()
+	defer resFile.Body.Close()
 
-	content, err := ioutil.ReadAll(res.Body)
+	content, err := ioutil.ReadAll(resFile.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Error while trying to read content from (%s)", ssLink)
 	}

--- a/crawler/prototipos/MPSP/crawler-mpsp.go
+++ b/crawler/prototipos/MPSP/crawler-mpsp.go
@@ -14,7 +14,7 @@ import (
 const linkPrincipal = "http://www.mpsp.mp.br/portal/page/portal/Portal_da_Transparencia/Contracheque/"
 
 //Last piece of URL where the links are found for each category of table
-var categories = [...]string{
+var categories = []string{
 	"Membros_ativos",
 	"Membros_inativos",
 	"Servidores_ativos",
@@ -30,7 +30,7 @@ var categories = [...]string{
 	//"Indenizacoes", Não existe
 }
 
-var meses = map[int]string{
+var months = map[int]string{
 	1:  "janeiro",
 	2:  "fevereiro",
 	3:  "março",
@@ -45,8 +45,23 @@ var meses = map[int]string{
 	12: "dezembro",
 }
 
+var fileNames = map[string]string{
+	"Membros_ativos":        "membros_ativos",
+	"Membros_inativos":      "membros_inativos",
+	"Servidores_ativos":     "servidores_ativos",
+	"servidores_inativos":   "servidores_inativos",
+	"valores_colaboradores": "colaboradores",
+	//Pensionistas separados
+	"Pensionistas/Pensionistas_membros":    "pensionistas_membros",
+	"Pensionistas/Pensionistas_servidores": "pensionistas_servidores",
+	//Verbas anteriores separadas
+	"Verbas-exec-anteriores/Verbas-exec-anteriores-Membros/Ativos_membros":   "exercicios_anteriores_membros_ativos",
+	"Verbas-exec-anteriores/Verbas-exec-anteriores-Membros/Inativos_membros": "exercicios_anteriores_membros_inativos",
+	"Verbas-exec-anteriores/Verbas-exec-anteriores-Servidores":               "exercicios_anteriores_servidores",
+}
+
 // Search for node descendants with the year text inside.
-func findYear(node *goquery.Selection, year string) bool {
+func hasYear(node *goquery.Selection, year string) bool {
 	for node.Size() != 0 {
 		if strings.Contains(node.Text(), year) {
 			return true
@@ -54,6 +69,22 @@ func findYear(node *goquery.Selection, year string) bool {
 		node = node.Children()
 	}
 	return false
+}
+
+// Search for a node in sel containing a given month in it's innerText and return it's href
+func contentLink(sel *goquery.Selection, month int) (string, error) {
+	monthStr := months[month]
+	for i := range sel.Nodes {
+		item := sel.Eq(i)
+		if strings.Contains(item.Text(), monthStr) {
+			link, ok := item.Attr("href")
+			if ok {
+				return link, nil
+			}
+			break
+		}
+	}
+	return "", fmt.Errorf("Couldn't find link for month %s", monthStr)
 }
 
 func fetchContent(category string, month int, year int) ([]byte, error) {
@@ -68,7 +99,6 @@ func fetchContent(category string, month int, year int) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error while casting reader to goquery.document (%s)", link)
 	}
-	res.Body.Close()
 
 	//Select tables of interest. According to html they are inside a td.
 	sel := doc.Find("td>table")
@@ -76,28 +106,28 @@ func fetchContent(category string, month int, year int) ([]byte, error) {
 	for i := range sel.Nodes {
 		node := sel.Eq(i)
 		//Try to find table with year inside, it will be right before the table with the actual links.
-		if findYear(node, fmt.Sprintf("%d", year)) {
+		if hasYear(node, fmt.Sprintf("%d", year)) {
 			//Nodes with info about the month links.
 			monthNodes = sel.Eq(i + 1).Find("a")
 			break
 		}
 	}
-	//Verify if given month exists
+
+	//Verify if there are any nodes in the search
 	if monthNodes == nil {
-		return nil, fmt.Errorf("Error, couldn't find year %d (%s)", year, link)
-	} else if monthNodes.Size() < month-1 {
-		return nil, fmt.Errorf("Error, couldn't find month %d (%s)", month, link)
-	}
-	//Find content url
-	ssLink, ok := monthNodes.Eq(month - 1).Attr("href")
-	if !ok {
-		return nil, fmt.Errorf("Error, couldn't find href for month %d (%s)", month, link)
+		return nil, fmt.Errorf("Error, couldn't find year %d", year)
 	}
 
-	//Fetch spreedsheet
+	//Find content url for a given month
+	ssLink, err := contentLink(monthNodes, month)
+	if err != nil {
+		return nil, err
+	}
+
+	//Fetch content
 	res, err = http.Get(ssLink)
 	if err != nil {
-		return nil, fmt.Errorf("Error while trying to make the Get request to (%s)", link)
+		return nil, fmt.Errorf("Error while trying to make the Get request to (%s)", ssLink)
 	}
 	defer res.Body.Close()
 
@@ -109,28 +139,8 @@ func fetchContent(category string, month int, year int) ([]byte, error) {
 }
 
 func saveFile(c []byte, year int, month int, category string) error {
-
-	//Correcting category name
-	switch category {
-	case "Pensionistas/Pensionistas_membros":
-		category = "pensionistas-membros"
-		break
-	case "Pensionistas/Pensionistas_servidores":
-		category = "pensionistas-servidores"
-		break
-	case "Verbas-exec-anteriores/Verbas-exec-anteriores-Membros/Ativos_membros":
-		category = "exec-anteriores-membros-ativos"
-		break
-	case "Verbas-exec-anteriores/Verbas-exec-anteriores-Membros/Inativos_membros":
-		category = "exec-anteriores-membros-inativos"
-		break
-	case "Verbas-exec-anteriores/Verbas-exec-anteriores-Servidores":
-		category = "exec-anteriores-servidores"
-		break
-	}
-
 	//Create a new file in the cwd
-	fileName := fmt.Sprintf("%s-%02d-%d", category, month, year)
+	fileName := fmt.Sprintf("%s-%02d-%d", fileNames[category], month, year)
 	file, err := os.Create(fileName)
 	if err != nil {
 		return fmt.Errorf("Error creating file(%s): %q", fileName, err)
@@ -157,13 +167,12 @@ func main() {
 	for _, category := range categories {
 		c, err := fetchContent(category, *month, *year)
 		if err != nil {
-			fmt.Printf("Error while trying to fetch content %s %d-%d: %q\n", category, *month, *year, err)
+			fmt.Printf("Error while trying to fetch content (%s %02d-%d): %q\n", fileNames[category], *month, *year, err)
 			continue
 		}
 		err = saveFile(c, *year, *month, category)
 		if err = saveFile(c, *year, *month, category); err != nil {
-			fmt.Printf("Error saving spreedsheet to file (%s %d-%d): %q\n", category, *month, *year, err)
+			fmt.Printf("Error saving content to file (%s %02d-%d): %q\n", fileNames[category], *month, *year, err)
 		}
 	}
-
 }

--- a/crawler/prototipos/MPSP/crawler-mpsp.go
+++ b/crawler/prototipos/MPSP/crawler-mpsp.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+const linkPrincipal = "http://www.mpsp.mp.br/portal/page/portal/Portal_da_Transparencia/Contracheque/"
+
+//Last piece of URL where the links are found for each category of table
+var categories = [...]string{
+	"Membros_ativos",
+	"Membros_inativos",
+	"Servidores_ativos",
+	"servidores_inativos",
+	"valores_colaboradores",
+	//Pensionistas separados
+	"Pensionistas/Pensionistas_membros",
+	"Pensionistas/Pensionistas_servidores",
+	//Verbas anteriores separadas
+	"Verbas-exec-anteriores/Verbas-exec-anteriores-Membros/Ativos_membros",
+	"Verbas-exec-anteriores/Verbas-exec-anteriores-Membros/Inativos_membros",
+	"Verbas-exec-anteriores/Verbas-exec-anteriores-Servidores",
+	//"Indenizacoes", Não existe
+}
+
+var meses = map[int]string{
+	1:  "janeiro",
+	2:  "fevereiro",
+	3:  "março",
+	4:  "abril",
+	5:  "maio",
+	6:  "junho",
+	7:  "julho",
+	8:  "agosto",
+	9:  "setembro",
+	10: "outubro",
+	11: "novembro",
+	12: "dezembro",
+}
+
+// Search for node descendants with the year text inside.
+func findYear(node *goquery.Selection, year string) bool {
+	for node.Size() != 0 {
+		if strings.Contains(node.Text(), year) {
+			return true
+		}
+		node = node.Children()
+	}
+	return false
+}
+
+func fetchContent(category string, month int, year int) ([]byte, error) {
+	link := fmt.Sprintf("%s%s", linkPrincipal, category)
+	res, err := http.Get(link)
+	if err != nil {
+		return nil, fmt.Errorf("Error while trying to make the Get request to (%s)", link)
+	}
+	defer res.Body.Close()
+
+	doc, err := goquery.NewDocumentFromReader(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Error while casting reader to goquery.document (%s)", link)
+	}
+	res.Body.Close()
+
+	//Select tables of interest. According to html they are inside a td.
+	sel := doc.Find("td>table")
+	var monthNodes *goquery.Selection
+	for i := range sel.Nodes {
+		node := sel.Eq(i)
+		//Try to find table with year inside, it will be right before the table with the actual links.
+		if findYear(node, fmt.Sprintf("%d", year)) {
+			//Nodes with info about the month links.
+			monthNodes = sel.Eq(i + 1).Find("a")
+			break
+		}
+	}
+	//Verify if given month exists
+	if monthNodes == nil {
+		return nil, fmt.Errorf("Error, couldn't find year %d (%s)", year, link)
+	} else if monthNodes.Size() < month-1 {
+		return nil, fmt.Errorf("Error, couldn't find month %d (%s)", month, link)
+	}
+	//Find content url
+	ssLink, ok := monthNodes.Eq(month - 1).Attr("href")
+	if !ok {
+		return nil, fmt.Errorf("Error, couldn't find href for month %d (%s)", month, link)
+	}
+
+	//Fetch spreedsheet
+	res, err = http.Get(ssLink)
+	if err != nil {
+		return nil, fmt.Errorf("Error while trying to make the Get request to (%s)", link)
+	}
+	defer res.Body.Close()
+
+	content, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Error while trying to read content from (%s)", ssLink)
+	}
+	return content, nil
+}
+
+func saveFile(c []byte, year int, month int, category string) error {
+
+	//Correcting category name
+	switch category {
+	case "Pensionistas/Pensionistas_membros":
+		category = "pensionistas-membros"
+		break
+	case "Pensionistas/Pensionistas_servidores":
+		category = "pensionistas-servidores"
+		break
+	case "Verbas-exec-anteriores/Verbas-exec-anteriores-Membros/Ativos_membros":
+		category = "exec-anteriores-membros-ativos"
+		break
+	case "Verbas-exec-anteriores/Verbas-exec-anteriores-Membros/Inativos_membros":
+		category = "exec-anteriores-membros-inativos"
+		break
+	case "Verbas-exec-anteriores/Verbas-exec-anteriores-Servidores":
+		category = "exec-anteriores-servidores"
+		break
+	}
+
+	//Create a new file in the cwd
+	fileName := fmt.Sprintf("%s-%02d-%d", category, month, year)
+	file, err := os.Create(fileName)
+	if err != nil {
+		return fmt.Errorf("Error creating file(%s): %q", fileName, err)
+	}
+	defer file.Close()
+
+	//Write to file
+	if _, err = file.Write(c); err != nil {
+		return fmt.Errorf("Error writing to file (%s): %q", fileName, err)
+	}
+	return nil
+}
+
+func main() {
+	month := flag.Int("mes", -1, "O mês da planilha")
+	year := flag.Int("ano", -1, "O ano da planilha")
+	flag.Parse()
+
+	if *month == -1 || *year == -1 {
+		fmt.Printf("Need flags \"--mes=int --ano=int\"\n")
+		return
+	}
+
+	for _, category := range categories {
+		c, err := fetchContent(category, *month, *year)
+		if err != nil {
+			fmt.Printf("Error while trying to fetch content %s %d-%d: %q\n", category, *month, *year, err)
+			continue
+		}
+		err = saveFile(c, *year, *month, category)
+		if err = saveFile(c, *year, *month, category); err != nil {
+			fmt.Printf("Error saving spreedsheet to file (%s %d-%d): %q\n", category, *month, *year, err)
+		}
+	}
+
+}


### PR DESCRIPTION
Crawler para recuperar as planilhas de remuneração do MPSP. Utiliza goquery para fazer um parse no html e encontrar os links de interesse com base na sua localização deterministica. 

#104 